### PR TITLE
Add validators for date (time)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-shared-sample-validation</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/ISODateRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/ISODateRule.java
@@ -1,0 +1,19 @@
+package uk.gov.ons.ssdc.common.validation;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import java.time.LocalDate;
+import java.util.Optional;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class ISODateRule implements Rule {
+
+  @Override
+  public Optional<String> checkValidity(String data) {
+    try {
+      LocalDate.parse(data);
+      return Optional.empty();
+    } catch (Exception e) {
+      return Optional.of("Not a valid ISO date");
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRule.java
@@ -1,0 +1,19 @@
+package uk.gov.ons.ssdc.common.validation;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class ISODateTimeRule implements Rule {
+
+  @Override
+  public Optional<String> checkValidity(String data) {
+    try {
+      ZonedDateTime.parse(data);
+      return Optional.empty();
+    } catch (Exception e) {
+      return Optional.of("Not a valid ISO date time");
+    }
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateRuleTest.java
@@ -1,0 +1,24 @@
+package uk.gov.ons.ssdc.common.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class ISODateRuleTest {
+
+  @Test
+  void checkValidityValid() {
+    ISODateRule underTest = new ISODateRule();
+    Optional<String> validity = underTest.checkValidity("2021-10-09");
+    assertThat(validity.isPresent()).isFalse();
+  }
+
+  @Test
+  void checkValidityInvalid() {
+    ISODateRule underTest = new ISODateRule();
+    Optional<String> validity = underTest.checkValidity("66-66-6666");
+    assertThat(validity.isPresent()).isTrue();
+    assertThat(validity.get()).isEqualTo("Not a valid ISO date");
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRuleTest.java
@@ -15,6 +15,13 @@ public class ISODateTimeRuleTest {
   }
 
   @Test
+  void checkValidityValidNoZ() {
+    ISODateTimeRule underTest = new ISODateTimeRule();
+    Optional<String> validity = underTest.checkValidity("2021-10-09T12:00+00");
+    assertThat(validity.isPresent()).isFalse();
+  }
+
+  @Test
   void checkValidityInvalid() {
     ISODateTimeRule underTest = new ISODateTimeRule();
     Optional<String> validity = underTest.checkValidity("66-66-6666:66:66:66.666Z");

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRuleTest.java
@@ -4,20 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class ISODateTimeRuleTest {
 
-  @Test
-  void checkValidityValid() {
+  @ParameterizedTest
+  @ValueSource(strings = {"2021-10-09T15:45:33.123Z", "2021-10-09T12:00+00"})
+  void checkValidityValid(String dateTime) {
     ISODateTimeRule underTest = new ISODateTimeRule();
-    Optional<String> validity = underTest.checkValidity("2021-10-09T15:45:33.123Z");
-    assertThat(validity.isPresent()).isFalse();
-  }
-
-  @Test
-  void checkValidityValidNoZ() {
-    ISODateTimeRule underTest = new ISODateTimeRule();
-    Optional<String> validity = underTest.checkValidity("2021-10-09T12:00+00");
+    Optional<String> validity = underTest.checkValidity(dateTime);
     assertThat(validity.isPresent()).isFalse();
   }
 

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateTimeRuleTest.java
@@ -1,0 +1,24 @@
+package uk.gov.ons.ssdc.common.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class ISODateTimeRuleTest {
+
+  @Test
+  void checkValidityValid() {
+    ISODateTimeRule underTest = new ISODateTimeRule();
+    Optional<String> validity = underTest.checkValidity("2021-10-09T15:45:33.123Z");
+    assertThat(validity.isPresent()).isFalse();
+  }
+
+  @Test
+  void checkValidityInvalid() {
+    ISODateTimeRule underTest = new ISODateTimeRule();
+    Optional<String> validity = underTest.checkValidity("66-66-6666:66:66:66.666Z");
+    assertThat(validity.isPresent()).isTrue();
+    assertThat(validity.get()).isEqualTo("Not a valid ISO date time");
+  }
+}


### PR DESCRIPTION
# Why
The SIS2 data we receive from RH will include a child's date of birth. We should validate that it conforms to ISO date standard (i.e. YYYY-MM-DD, e.g. 2010-12-31).
We might also receive ISO dates with times (e.g. 2010-12-31T23:59.59.123Z) so we might as well build a validator for that format too

# How?
Validators added

# Test?
Build this, along with all the other PRs on the ticket, then validate some samples that have a date in. Also run the ATs

https://trello.com/c/bMLqKgjz/2946-iso-datetime-and-iso-date-sample-column-validators-5