### PR TITLE
3070 build shared sample validation release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+# What has changed
+<!--- What code changes has been made -->
+<!--- Has there been any refactoring -->
+<!--- What tests have been written -->
+
+# How to test?
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
+<!--- Are there any automated tests that mean changes don't need to be manually changed -->
+
+# Links
+<!--- Add any links to issues (trello, github issues) -->
+<!--- Links to any documentation -->
+<!--- Links to any related PRs -->
+
+# Screenshots (if appropriate):

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>artifact-registry</id>
+      <id>artifact-registry-snapshots</id>
       <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-ci/rm-snapshots</url>
     </snapshotRepository>
     <repository>
-      <id>artifact-registry</id>
-      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-ci/rm-snapshots</url>
+      <id>artifact-registry-releases</id>
+      <url>artifactregistry://europe-west2-maven.pkg.dev/ons-ci-rm/rm-releases</url>
     </repository>
   </distributionManagement>
 
@@ -36,10 +36,20 @@
       <id>artifact-registry</id>
       <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-ci/rm-snapshots</url>
       <releases>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>artifact-registry-prod</id>
+      <url>artifactregistry://europe-west2-maven.pkg.dev/ons-ci-rm/rm-releases</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
       </snapshots>
     </repository>
   </repositories>


### PR DESCRIPTION
# Motivation and Context
RELEASE artifacts need to go the the releases repository in ons-ci-rm.  SNAPSHOT ones will continue to go to the repository in ssdc-rm-ci as normal.  This is pretty much a copy of what's already been tried and tested for the common-entity-model repo.

# What has changed
- Changes to the pom file
- Added a Git template to make future PRs easier

# How to test?
- Run a `mvn deploy` when the release is `x.x.x-SNAPSHOT` and the artifacts should be pushed to the artifact repository in ssdc-rm-ci (assuming you have the permissions to do so)
- Run a `mvn deploy` when the release is `x.x.x-RELEASE` and the artifacts should be pushed to the artifact repository in ons-rm-ci (assuming you have the permissions to do so)

# Links
- https://trello.com/c/d7cWeH4n