### PR TITLE
Upgrade Cloud Build to JDK 17

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: maven:3-jdk-11
+  - name: maven:3-openjdk-17
     entrypoint: mvn
     args: ['deploy']
 logsBucket: 'gs://ssdc-rm-ci-cloud-build-logging'


### PR DESCRIPTION
# Motivation and Context
Forgot to bump the Cloud Build version to JDK 17.

# What has changed
Switched to use `maven:3-openjdk-17` image for the cloud build.

# How to test?
Approve it. Merge it. Fail forwards.

# Links
Trello: https://trello.com/c/kcJGECdH