### PR TITLE
2990 enhance logging on validation errors when creating updating a case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-shared-sample-validation</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
@@ -56,7 +56,7 @@ public class ColumnValidator implements Serializable {
     return Optional.empty();
   }
 
-  public Optional<String> validateRowWithDateExcludedErrorMsgs(Map<String, String> rowData) {
+  public Optional<String> validateRowWithDataExcludedErrorMsgs(Map<String, String> rowData) {
     List<String> validationErrors = new LinkedList<>();
 
     for (Rule rule : rules) {

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
@@ -32,45 +32,38 @@ public class ColumnValidator implements Serializable {
   }
 
   public Optional<String> validateRow(Map<String, String> rowData) {
-    List<String> validationErrors = new LinkedList<>();
-
-    for (Rule rule : rules) {
-      String dataToValidate = rowData.get(columnName);
-
-      Optional<String> validationError = rule.checkValidity(dataToValidate);
-      if (validationError.isPresent()) {
-        validationErrors.add(
-            "Column '"
-                + columnName
-                + "' value '"
-                + dataToValidate
-                + "' validation error: "
-                + validationError.get());
-      }
-    }
-
-    if (validationErrors.size() > 0) {
-      return Optional.of(String.join(", ", validationErrors));
-    }
-
-    return Optional.empty();
+    return validateData(rowData.get(columnName), false);
   }
 
-  public Optional<String> validateRowWithDataExcludedErrorMsgs(Map<String, String> rowData) {
+  public Optional<String> validateRow(
+      Map<String, String> rowData, boolean excludeDataFromReturnedErrorMsgs) {
+    return validateData(rowData.get(columnName), excludeDataFromReturnedErrorMsgs);
+  }
+
+  public Optional<String> validateData(
+      String dataToValidate, boolean excludeDataFromReturnedErrorMsgs) {
     List<String> validationErrors = new LinkedList<>();
 
     for (Rule rule : rules) {
-      String dataToValidate = rowData.get(columnName);
-
       Optional<String> validationError = rule.checkValidity(dataToValidate);
       if (validationError.isPresent()) {
-        validationErrors.add(
-            "Column '"
-                + columnName
-                + "' Failed validation for Rule '"
-                + rule.getClass().getSimpleName()
-                + "' validation error: "
-                + validationError.get());
+        if (excludeDataFromReturnedErrorMsgs) {
+          validationErrors.add(
+              "Column '"
+                  + columnName
+                  + "' Failed validation for Rule '"
+                  + rule.getClass().getSimpleName()
+                  + "' validation error: "
+                  + validationError.get());
+        } else {
+          validationErrors.add(
+              "Column '"
+                  + columnName
+                  + "' value '"
+                  + dataToValidate
+                  + "' validation error: "
+                  + validationError.get());
+        }
       }
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
@@ -67,7 +67,7 @@ public class ColumnValidator implements Serializable {
         validationErrors.add(
             "Column '"
                 + columnName
-                + " Failed validation for Rule '"
+                + "' Failed validation for Rule '"
                 + rule.getClass().getSimpleName()
                 + "' validation error: "
                 + validationError.get());

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/ColumnValidator.java
@@ -56,6 +56,31 @@ public class ColumnValidator implements Serializable {
     return Optional.empty();
   }
 
+  public Optional<String> validateRowWithDateExcludedErrorMsgs(Map<String, String> rowData) {
+    List<String> validationErrors = new LinkedList<>();
+
+    for (Rule rule : rules) {
+      String dataToValidate = rowData.get(columnName);
+
+      Optional<String> validationError = rule.checkValidity(dataToValidate);
+      if (validationError.isPresent()) {
+        validationErrors.add(
+            "Column '"
+                + columnName
+                + " Failed validation for Rule '"
+                + rule.getClass().getSimpleName()
+                + "' validation error: "
+                + validationError.get());
+      }
+    }
+
+    if (validationErrors.size() > 0) {
+      return Optional.of(String.join(", ", validationErrors));
+    }
+
+    return Optional.empty();
+  }
+
   public String getColumnName() {
     return columnName;
   }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
@@ -10,7 +10,7 @@ class ColumnValidatorTest {
   private static final String ERROR_MSG_INCLUDING_DATA =
       "Column 'col1' value 'bar' validation error: Not in set of foo";
   private static final String ERROR_MSG_EXCLUDING_DATA =
-      "Column 'col1 Failed validation for Rule 'InSetRule' validation error: Not in set of foo";
+      "Column 'col1' Failed validation for Rule 'InSetRule' validation error: Not in set of foo";
 
   @Test
   public void validateRowSuccess() {

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
@@ -1,0 +1,62 @@
+package uk.gov.ons.ssdc.common.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ColumnValidatorTest {
+  private static final String ERROR_MSG_INCLUDING_DATA =
+      "Column 'col1' value 'bar' validation error: Not in set of foo";
+  private static final String ERROR_MSG_EXCLUDING_DATA =
+      "Column 'col1 Failed validation for Rule 'InSetRule' validation error: Not in set of foo";
+
+  @Test
+  public void validateRowSuccess() {
+    InSetRule inSetRule = new InSetRule(new String[] {"foo", "bar"});
+    ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
+
+    Map<String, String> dataRow = Map.of("col1", "foo");
+    Optional<String> actualValidationResult = underTest.validateRow(dataRow);
+
+    assertThat(actualValidationResult).isEmpty();
+  }
+
+  @Test
+  public void validateRowError() {
+    InSetRule inSetRule = new InSetRule(new String[] {"foo"});
+    ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
+
+    Map<String, String> dataRow = Map.of("col1", "bar");
+    Optional<String> actualValidationResult = underTest.validateRow(dataRow);
+
+    assertThat(actualValidationResult).isPresent();
+    assertThat(actualValidationResult.get()).isEqualTo(ERROR_MSG_INCLUDING_DATA);
+  }
+
+  @Test
+  public void validateRowWithDateExcludedErrorMsgsSuccess() {
+    InSetRule inSetRule = new InSetRule(new String[] {"foo", "bar"});
+    ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
+
+    Map<String, String> dataRow = Map.of("col1", "foo");
+    Optional<String> actualValidationResult =
+        underTest.validateRowWithDateExcludedErrorMsgs(dataRow);
+
+    assertThat(actualValidationResult).isEmpty();
+  }
+
+  @Test
+  public void validateRowWithDateExcludedErrorMsgsError() {
+    InSetRule inSetRule = new InSetRule(new String[] {"foo"});
+    ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
+
+    Map<String, String> dataRow = Map.of("col1", "bar");
+    Optional<String> actualValidationResult =
+        underTest.validateRowWithDateExcludedErrorMsgs(dataRow);
+
+    assertThat(actualValidationResult).isPresent();
+    assertThat(actualValidationResult.get()).isEqualTo(ERROR_MSG_EXCLUDING_DATA);
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
@@ -42,7 +42,7 @@ class ColumnValidatorTest {
 
     Map<String, String> dataRow = Map.of("col1", "foo");
     Optional<String> actualValidationResult =
-        underTest.validateRowWithDateExcludedErrorMsgs(dataRow);
+        underTest.validateRowWithDataExcludedErrorMsgs(dataRow);
 
     assertThat(actualValidationResult).isEmpty();
   }
@@ -54,7 +54,7 @@ class ColumnValidatorTest {
 
     Map<String, String> dataRow = Map.of("col1", "bar");
     Optional<String> actualValidationResult =
-        underTest.validateRowWithDateExcludedErrorMsgs(dataRow);
+        underTest.validateRowWithDataExcludedErrorMsgs(dataRow);
 
     assertThat(actualValidationResult).isPresent();
     assertThat(actualValidationResult.get()).isEqualTo(ERROR_MSG_EXCLUDING_DATA);

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
@@ -41,8 +41,7 @@ class ColumnValidatorTest {
     ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
 
     Map<String, String> dataRow = Map.of("col1", "foo");
-    Optional<String> actualValidationResult =
-        underTest.validateRowWithDataExcludedErrorMsgs(dataRow);
+    Optional<String> actualValidationResult = underTest.validateRow(dataRow, true);
 
     assertThat(actualValidationResult).isEmpty();
   }
@@ -53,8 +52,7 @@ class ColumnValidatorTest {
     ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
 
     Map<String, String> dataRow = Map.of("col1", "bar");
-    Optional<String> actualValidationResult =
-        underTest.validateRowWithDataExcludedErrorMsgs(dataRow);
+    Optional<String> actualValidationResult = underTest.validateRow(dataRow, true);
 
     assertThat(actualValidationResult).isPresent();
     assertThat(actualValidationResult.get()).isEqualTo(ERROR_MSG_EXCLUDING_DATA);


### PR DESCRIPTION
# Motivation and Context
Currently for sample update, sensitiveSample update and newCase events we cannot log error reasons - because the errors returned contain data we do not wish to log.  And no Rule is mentioned either.

# What has changed
New method: validateRowWithDateExcludedErrorMsgs. 
This returns validation errors without any data in, but with rule name.

NOTE:  This cannot protect against 2 weaknesses.
1) The consume of this message may decide to enrich with the data - which in our context at least would be wrong.
2) A new rule could be created, or existing rule altered to return the data that failed - rather than a just the reason.


# How to test?
With other bits installed from this ticket.  Throw some bad messages at caseprocessor and check logging is as expected now.

# Links
https://trello.com/b/yarvSxGu/generic-response-management
