### PR TITLE
289 Add label check action workflow

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,24 @@
+---
+name: Label Checker
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: docker://onsdigital/github-pr-label-checker:v1.2.7
+        with:
+          one_of: breaking change,feature,patch
+          none_of: do not merge,work in progress
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Motivation and Context
We want to enforce labelling on our Github PRs, changes must include a semantic versioning indicator, one of `breaking change`, `feature` or `patch`, and neither `do not merge` nor `work in progress`

# What has changed
- Add label checker Github action workflow

# How to test?
Check the label check action is configured correctly and running on this PR.

# Links
https://trello.com/c/Kgfdilff/289-enforce-pr-labels-with-github-action-8