### PR TITLE
420 Add Numeric Rule and mandatory parameter to EmailRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-shared-sample-validation</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/EmailRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/EmailRule.java
@@ -1,6 +1,10 @@
 package uk.gov.ons.ssdc.common.validation;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.NoArgsConstructor;
+
 import java.net.IDN;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -41,8 +45,21 @@ public class EmailRule implements Rule {
   private static final Pattern topLevelDomainPattern =
       Pattern.compile(TOP_LEVEL_DOMAIN_REGEX, Pattern.CASE_INSENSITIVE);
 
+  private boolean optional = false;
+
+
+  @JsonCreator
+  public EmailRule(@JsonProperty(value = "optional") boolean optional) {
+    this.optional = optional;
+  }
+
+
   @Override
   public Optional<String> checkValidity(String data) {
+
+    if (this.optional && data.isEmpty()) {
+      return Optional.empty();
+    }
 
     Optional<String> errorsOpt = checkBasicRegexLengthAndPeriods(data);
     if (errorsOpt.isPresent()) {

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/EmailRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/EmailRule.java
@@ -43,17 +43,17 @@ public class EmailRule implements Rule {
   private static final Pattern topLevelDomainPattern =
       Pattern.compile(TOP_LEVEL_DOMAIN_REGEX, Pattern.CASE_INSENSITIVE);
 
-  private boolean optional;
+  private final boolean mandatory;
 
   @JsonCreator
-  public EmailRule(@JsonProperty(value = "optional") boolean optional) {
-    this.optional = optional;
+  public EmailRule(@JsonProperty(value = "mandatory") boolean mandatory) {
+    this.mandatory = mandatory;
   }
 
   @Override
   public Optional<String> checkValidity(String data) {
 
-    if (this.optional && data.isEmpty()) {
+    if (!this.mandatory && data.isEmpty()) {
       return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/EmailRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/EmailRule.java
@@ -3,8 +3,6 @@ package uk.gov.ons.ssdc.common.validation;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.NoArgsConstructor;
-
 import java.net.IDN;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -45,14 +43,12 @@ public class EmailRule implements Rule {
   private static final Pattern topLevelDomainPattern =
       Pattern.compile(TOP_LEVEL_DOMAIN_REGEX, Pattern.CASE_INSENSITIVE);
 
-  private boolean optional = false;
-
+  private boolean optional;
 
   @JsonCreator
   public EmailRule(@JsonProperty(value = "optional") boolean optional) {
     this.optional = optional;
   }
-
 
   @Override
   public Optional<String> checkValidity(String data) {

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/NumericRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/NumericRule.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.ssdc.common.validation;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import java.util.Optional;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class NumericRule implements Rule {
   @Override
   public Optional<String> checkValidity(String data) {

--- a/src/main/java/uk/gov/ons/ssdc/common/validation/NumericRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/validation/NumericRule.java
@@ -1,0 +1,14 @@
+package uk.gov.ons.ssdc.common.validation;
+
+import java.util.Optional;
+
+public class NumericRule implements Rule {
+  @Override
+  public Optional<String> checkValidity(String data) {
+    if (data.matches("\\d*")) {
+      return Optional.empty();
+    }
+
+    return Optional.of("Contains non digit characters");
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ColumnValidatorTest.java
@@ -13,7 +13,7 @@ class ColumnValidatorTest {
       "Column 'col1' Failed validation for Rule 'InSetRule' validation error: Not in set of foo";
 
   @Test
-  public void validateRowSuccess() {
+  void validateRowSuccess() {
     InSetRule inSetRule = new InSetRule(new String[] {"foo", "bar"});
     ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
 
@@ -24,19 +24,18 @@ class ColumnValidatorTest {
   }
 
   @Test
-  public void validateRowError() {
+  void validateRowError() {
     InSetRule inSetRule = new InSetRule(new String[] {"foo"});
     ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
 
     Map<String, String> dataRow = Map.of("col1", "bar");
     Optional<String> actualValidationResult = underTest.validateRow(dataRow);
 
-    assertThat(actualValidationResult).isPresent();
-    assertThat(actualValidationResult.get()).isEqualTo(ERROR_MSG_INCLUDING_DATA);
+    assertThat(actualValidationResult).isPresent().contains(ERROR_MSG_INCLUDING_DATA);
   }
 
   @Test
-  public void validateRowWithDateExcludedErrorMsgsSuccess() {
+  void validateRowWithDateExcludedErrorMsgsSuccess() {
     InSetRule inSetRule = new InSetRule(new String[] {"foo", "bar"});
     ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
 
@@ -47,14 +46,13 @@ class ColumnValidatorTest {
   }
 
   @Test
-  public void validateRowWithDateExcludedErrorMsgsError() {
+  void validateRowWithDateExcludedErrorMsgsError() {
     InSetRule inSetRule = new InSetRule(new String[] {"foo"});
     ColumnValidator underTest = new ColumnValidator("col1", false, new Rule[] {inSetRule});
 
     Map<String, String> dataRow = Map.of("col1", "bar");
     Optional<String> actualValidationResult = underTest.validateRow(dataRow, true);
 
-    assertThat(actualValidationResult).isPresent();
-    assertThat(actualValidationResult.get()).isEqualTo(ERROR_MSG_EXCLUDING_DATA);
+    assertThat(actualValidationResult).isPresent().contains(ERROR_MSG_EXCLUDING_DATA);
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
@@ -1,14 +1,12 @@
 package uk.gov.ons.ssdc.common.validation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 
 class EmailRuleTest {
 
@@ -21,59 +19,59 @@ class EmailRuleTest {
 
   private static Stream<Arguments> validEmailProvider() {
     return Stream.of(
-        "email@domain.com",
-        "email@domain.COM",
-        "firstname.lastname@domain.com",
-        "firstname.o\'lastname@domain.com",
-        "email@subdomain.domain.com",
-        "firstname+lastname@domain.com",
-        "1234567890@domain.com",
-        "email@domain-one.com",
-        "_______@domain.com",
-        "email@domain.name",
-        "email@domain.superlongtld",
-        "email@domain.co.jp",
-        "firstname-lastname@domain.com",
-        "info@german-financial-services.vermögensberatung",
-        "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
-        "japanese-info@例え.テスト",
-        "email@double--hyphen.com").map(Arguments::of);
+            "email@domain.com",
+            "email@domain.COM",
+            "firstname.lastname@domain.com",
+            "firstname.o\'lastname@domain.com",
+            "email@subdomain.domain.com",
+            "firstname+lastname@domain.com",
+            "1234567890@domain.com",
+            "email@domain-one.com",
+            "_______@domain.com",
+            "email@domain.name",
+            "email@domain.superlongtld",
+            "email@domain.co.jp",
+            "firstname-lastname@domain.com",
+            "info@german-financial-services.vermögensberatung",
+            "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
+            "japanese-info@例え.テスト",
+            "email@double--hyphen.com")
+        .map(Arguments::of);
   }
 
   private static Stream<Arguments> invalidEmailProvider() {
     return Stream.of(
-        "email@123.123.123.123",
-        "email@[123.123.123.123]",
-        "plainaddress",
-        "@no-local-part.com",
-        "Outlook Contact <outlook-contact@domain.com>",
-        "no-at.domain.com",
-        "no-tld@domain",
-        ";beginning-semicolon@domain.co.uk",
-        "middle-semicolon@domain.co;uk",
-        "trailing-semicolon@domain.com;",
-        "\"email+leading-quotes@domain.com",
-        "email+middle\"-quotes@domain.com",
-        "\"quoted-local-part\"@domain.com",
-        "\"quoted@domain.com\"",
-        "lots-of-dots@domain..gov..uk",
-        "two-dots..in-local@domain.com",
-        "multiple@domains@domain.com",
-        "spaces in local@domain.com",
-        "spaces-in-domain@dom ain.com",
-        "underscores-in-domain@dom_ain.com",
-        "pipe-in-domain@example.com|gov.uk",
-        "comma,in-local@gov.uk",
-        "comma-in-domain@domain,gov.uk",
-        "pound-sign-in-local£@domain.com",
-        "local-with-’-apostrophe@domain.com",
-        "local-with-”-quotes@domain.com",
-        "domain-starts-with-a-dot@.domain.com",
-        "brackets(in)local@domain.com",
-        "incorrect-punycode@xn---something.com").map(Arguments::of);
-  }
-
-  ;
+            "email@123.123.123.123",
+            "email@[123.123.123.123]",
+            "plainaddress",
+            "@no-local-part.com",
+            "Outlook Contact <outlook-contact@domain.com>",
+            "no-at.domain.com",
+            "no-tld@domain",
+            ";beginning-semicolon@domain.co.uk",
+            "middle-semicolon@domain.co;uk",
+            "trailing-semicolon@domain.com;",
+            "\"email+leading-quotes@domain.com",
+            "email+middle\"-quotes@domain.com",
+            "\"quoted-local-part\"@domain.com",
+            "\"quoted@domain.com\"",
+            "lots-of-dots@domain..gov..uk",
+            "two-dots..in-local@domain.com",
+            "multiple@domains@domain.com",
+            "spaces in local@domain.com",
+            "spaces-in-domain@dom ain.com",
+            "underscores-in-domain@dom_ain.com",
+            "pipe-in-domain@example.com|gov.uk",
+            "comma,in-local@gov.uk",
+            "comma-in-domain@domain,gov.uk",
+            "pound-sign-in-local£@domain.com",
+            "local-with-’-apostrophe@domain.com",
+            "local-with-”-quotes@domain.com",
+            "domain-starts-with-a-dot@.domain.com",
+            "brackets(in)local@domain.com",
+            "incorrect-punycode@xn---something.com")
+        .map(Arguments::of);
+  };
 
   @ParameterizedTest
   @MethodSource("validEmailProvider")
@@ -103,7 +101,6 @@ class EmailRuleTest {
   void testValidateEmailAddressesOptionalInvalid(String emailAddress) {
     assertThat(optionalEmailRule.checkValidity(emailAddress)).isNotEmpty();
   }
-
 
   @Test
   void testValidateEmailAddressOptionalEmptyValid() {

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class EmailRuleTest {
 
   EmailRule emailRule = new EmailRule(false);
-  EmailRule optionalEmailRule = new EmailRule(true);
+  EmailRule mandatoryEmailRule = new EmailRule(true);
 
   /* correct and incorrect email addresses from:
   https://github.com/alphagov/notifications-utils/blob/7d48b8f825fafb0db0bad106ccccdd1f889cf657/tests/test_recipient_validation.py#L101
@@ -86,25 +86,25 @@ class EmailRuleTest {
   }
 
   @Test
-  void testValidateEmailAddressEmptyInvalid() {
-    assertThat(emailRule.checkValidity("")).isNotEmpty();
+  void testValidateEmailAddressEmptyValid() {
+    assertThat(emailRule.checkValidity("")).isEmpty();
   }
 
   @ParameterizedTest
   @MethodSource("validEmailProvider")
-  void testValidateEmailAddressOptionalValid(String emailAddress) {
-    assertThat(optionalEmailRule.checkValidity(emailAddress)).isEmpty();
+  void testValidateEmailAddressMandatoryValid(String emailAddress) {
+    assertThat(mandatoryEmailRule.checkValidity(emailAddress)).isEmpty();
   }
 
   @ParameterizedTest
   @MethodSource("invalidEmailProvider")
-  void testValidateEmailAddressesOptionalInvalid(String emailAddress) {
-    assertThat(optionalEmailRule.checkValidity(emailAddress)).isNotEmpty();
+  void testValidateEmailAddressesMandatoryInvalid(String emailAddress) {
+    assertThat(mandatoryEmailRule.checkValidity(emailAddress)).isNotEmpty();
   }
 
   @Test
-  void testValidateEmailAddressOptionalEmptyValid() {
-    assertThat(optionalEmailRule.checkValidity("")).isEmpty();
+  void testValidateEmailAddressMandatoryEmptyInvalid() {
+    assertThat(mandatoryEmailRule.checkValidity("")).isNotEmpty();
   }
 
   // separate java test for this as different test/formatting syntax from Python

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ISODateRuleTest.java
@@ -5,20 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
-public class ISODateRuleTest {
+class ISODateRuleTest {
 
   @Test
   void checkValidityValid() {
     ISODateRule underTest = new ISODateRule();
     Optional<String> validity = underTest.checkValidity("2021-10-09");
-    assertThat(validity.isPresent()).isFalse();
+    assertThat(validity).isNotPresent();
   }
 
   @Test
   void checkValidityInvalid() {
     ISODateRule underTest = new ISODateRule();
     Optional<String> validity = underTest.checkValidity("66-66-6666");
-    assertThat(validity.isPresent()).isTrue();
-    assertThat(validity.get()).isEqualTo("Not a valid ISO date");
+    assertThat(validity).isPresent().contains("Not a valid ISO date");
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/InSetRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/InSetRuleTest.java
@@ -12,14 +12,14 @@ class InSetRuleTest {
   void checkValidityValid() {
     InSetRule underTest = new InSetRule(new String[] {"foo", "bar"});
     Optional<String> validity = underTest.checkValidity("foo");
-    assertThat(validity.isPresent()).isFalse();
+    assertThat(validity).isNotPresent();
   }
 
   @Test
   void checkValidityInvalid() {
     InSetRule underTest = new InSetRule(new String[] {"foo", "bar"});
     Optional<String> validity = underTest.checkValidity("baz");
-    assertThat(validity.isPresent()).isTrue();
+    assertThat(validity).isPresent();
     assertThat(validity.get()).startsWith("Not in set of");
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/LengthRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/LengthRuleTest.java
@@ -1,10 +1,10 @@
 package uk.gov.ons.ssdc.common.validation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
-import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LengthRuleTest {
 
@@ -12,14 +12,13 @@ class LengthRuleTest {
   void checkValidityValid() {
     LengthRule underTest = new LengthRule(5);
     Optional<String> validity = underTest.checkValidity("12345");
-    assertThat(validity.isPresent()).isFalse();
+    assertThat(validity).isNotPresent();
   }
 
   @Test
   void checkValidityInvalid() {
     LengthRule underTest = new LengthRule(5);
     Optional<String> validity = underTest.checkValidity("1234567890");
-    assertThat(validity.isPresent()).isTrue();
-    assertThat(validity.get()).isEqualTo("Exceeded max length of 5");
+    assertThat(validity).isPresent().contains("Exceeded max length of 5");
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/LengthRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/LengthRuleTest.java
@@ -1,10 +1,9 @@
 package uk.gov.ons.ssdc.common.validation;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class LengthRuleTest {
 

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/MandatoryRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/MandatoryRuleTest.java
@@ -12,14 +12,13 @@ class MandatoryRuleTest {
   void checkValidityValid() {
     MandatoryRule underTest = new MandatoryRule();
     Optional<String> validity = underTest.checkValidity("foo");
-    assertThat(validity.isPresent()).isFalse();
+    assertThat(validity).isNotPresent();
   }
 
   @Test
   void checkValidityInvalid() {
     MandatoryRule underTest = new MandatoryRule();
     Optional<String> validity = underTest.checkValidity("");
-    assertThat(validity.isPresent()).isTrue();
-    assertThat(validity.get()).isEqualTo("Mandatory value missing");
+    assertThat(validity).isPresent().contains("Mandatory value missing");
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/NumericRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/NumericRuleTest.java
@@ -1,0 +1,39 @@
+package uk.gov.ons.ssdc.common.validation;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class NumericRuleTest {
+  private static final NumericRule numericRule = new NumericRule();
+
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "1",
+      "0123456789",
+      "123",
+      "0000000000",
+      "",
+  })
+  void testValidNumericStrings(String validString) {
+    assertThat(numericRule.checkValidity(validString)).isNotPresent();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "a",
+      "a0123456789",
+      "*",
+      "-1",
+      "1.0",
+      "I am not a number",
+      "10e10",
+      "100L",
+  })
+  void testinvalidNumericStrings(String invalidString) {
+    assertThat(numericRule.checkValidity(invalidString)).isPresent();
+  }
+}

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/NumericRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/NumericRuleTest.java
@@ -1,38 +1,38 @@
 package uk.gov.ons.ssdc.common.validation;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class NumericRuleTest {
   private static final NumericRule numericRule = new NumericRule();
 
-
   @ParameterizedTest
-  @ValueSource(strings = {
-      "1",
-      "0123456789",
-      "123",
-      "0000000000",
-      "",
-  })
+  @ValueSource(
+      strings = {
+        "1",
+        "0123456789",
+        "123",
+        "0000000000",
+        "",
+      })
   void testValidNumericStrings(String validString) {
     assertThat(numericRule.checkValidity(validString)).isNotPresent();
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-      "a",
-      "a0123456789",
-      "*",
-      "-1",
-      "1.0",
-      "I am not a number",
-      "10e10",
-      "100L",
-  })
+  @ValueSource(
+      strings = {
+        "a",
+        "a0123456789",
+        "*",
+        "-1",
+        "1.0",
+        "I am not a number",
+        "10e10",
+        "100L",
+      })
   void testinvalidNumericStrings(String invalidString) {
     assertThat(numericRule.checkValidity(invalidString)).isPresent();
   }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/ReadValidationConfigTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/ReadValidationConfigTest.java
@@ -6,16 +6,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.FileInputStream;
 import org.junit.jupiter.api.Test;
 
-public class ReadValidationConfigTest {
+class ReadValidationConfigTest {
   ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  public void testCanReadValidationJson() throws Exception {
+  void testCanReadValidationJson() throws Exception {
     try (FileInputStream fis =
         new FileInputStream("src/test/resources/example-validator-config.json")) {
       ColumnValidator[] columnValidators = objectMapper.readValue(fis, ColumnValidator[].class);
 
-      assertThat(columnValidators.length).isGreaterThan(0);
+      assertThat(columnValidators.length).isPositive();
     }
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/RegexRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/RegexRuleTest.java
@@ -15,7 +15,7 @@ class RegexRuleTest {
         new RegexRule(TEST_REGEX_UK_MOBILE_NUMBER, TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
 
     Optional<String> actualResult = underTest.checkValidity("07123456789");
-    assertThat(actualResult.isPresent()).isFalse();
+    assertThat(actualResult).isNotPresent();
   }
 
   @Test
@@ -24,8 +24,7 @@ class RegexRuleTest {
         new RegexRule(TEST_REGEX_UK_MOBILE_NUMBER, TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
 
     Optional<String> actualResult = underTest.checkValidity("07123456xxx");
-    assertThat(actualResult.isPresent()).isTrue();
-    assertThat(actualResult.get()).isEqualTo(TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
+    assertThat(actualResult).isPresent().contains(TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
   }
 
   @Test
@@ -34,8 +33,7 @@ class RegexRuleTest {
         new RegexRule(TEST_REGEX_UK_MOBILE_NUMBER, TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
 
     Optional<String> actualResult = underTest.checkValidity("0712345");
-    assertThat(actualResult.isPresent()).isTrue();
-    assertThat(actualResult.get()).isEqualTo(TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
+    assertThat(actualResult).isPresent().contains(TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
   }
 
   @Test
@@ -44,7 +42,6 @@ class RegexRuleTest {
         new RegexRule(TEST_REGEX_UK_MOBILE_NUMBER, TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
 
     Optional<String> actualResult = underTest.checkValidity("07123456789123456789");
-    assertThat(actualResult.isPresent()).isTrue();
-    assertThat(actualResult.get()).isEqualTo(TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
+    assertThat(actualResult).isPresent().contains(TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
   }
 }

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/UUIDRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/UUIDRuleTest.java
@@ -13,14 +13,13 @@ class UUIDRuleTest {
   void checkValidityValid() {
     UUIDRule underTest = new UUIDRule();
     Optional<String> validity = underTest.checkValidity(UUID.randomUUID().toString());
-    assertThat(validity.isPresent()).isFalse();
+    assertThat(validity).isNotPresent();
   }
 
   @Test
   void checkValidityInvalid() {
     UUIDRule underTest = new UUIDRule();
     Optional<String> validity = underTest.checkValidity("this clearly is not a UUID");
-    assertThat(validity.isPresent()).isTrue();
-    assertThat(validity.get()).isEqualTo("Not a valid UUID");
+    assertThat(validity).isPresent().contains("Not a valid UUID");
   }
 }

--- a/src/test/resources/example-validator-config.json
+++ b/src/test/resources/example-validator-config.json
@@ -58,5 +58,24 @@
         "userFriendlyError": "Invalid UK mobile phone number"
       }
     ]
+  },
+  {
+    "columnName": "NUMERIC_ID",
+    "rules": [
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.NumericRule"
+      }
+    ]
+  },
+  {
+    "columnName": "MANDATORY_EMAIL",
+    "rules": [
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.EmailRule"
+      }
+    ]
   }
 ]

--- a/src/test/resources/example-validator-config.json
+++ b/src/test/resources/example-validator-config.json
@@ -74,7 +74,8 @@
     "columnName": "MANDATORY_EMAIL",
     "rules": [
       {
-        "className": "uk.gov.ons.ssdc.common.validation.EmailRule"
+        "className": "uk.gov.ons.ssdc.common.validation.EmailRule",
+        "mandatory": true
       }
     ]
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want a Numeric characters rule which only allows digits. Also change the email rule to allow for optional email columns and have a `mandatory` parameter.

Note this is breaking change because the email column was implicitly mandatory before, but is now by default optional.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add numeric rule and tests
- Add email rule mandatory parameter and tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Checkout and build this branch, then build the branch of case processor and support tool and try defining/loading a sample with numeric columns and optional emails.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/4pMbQWfO/426-sample-generator-numeric-only-rule
https://trello.com/c/69XMsVj3/420-create-and-test-loading-a-cis-sample-file-3