### PR TITLE
431 Remove snapshot cloudbuild

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+# Has the POM been updated?
+The [pom.xml](pom.xml) file `project.version` must be bumped appropriately on any code changes.
+- [] the POM has been updated with an appropriate version bump
+
 # Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 # Has the POM been updated?
+
 The [pom.xml](pom.xml) file `project.version` must be bumped appropriately on any code changes.
-- [] the POM has been updated with an appropriate version bump
+
+* [ ] the POM has been updated with an appropriate version bump if required
 
 # Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,0 @@
-steps:
-  - name: maven:3-openjdk-17
-    entrypoint: mvn
-    args: ['deploy']
-logsBucket: 'gs://ssdc-rm-ci-cloud-build-logging'

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,13 @@
   <distributionManagement>
     <snapshotRepository>
       <id>artifact-registry-snapshots</id>
-      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-ci/rm-snapshots</url>
+<!--      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-ci/rm-snapshots</url>-->
+      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-adamhawtin/test-snapshots</url>
     </snapshotRepository>
     <repository>
       <id>artifact-registry-releases</id>
-      <url>artifactregistry://europe-west2-maven.pkg.dev/ons-ci-rm/rm-releases</url>
+<!--      <url>artifactregistry://europe-west2-maven.pkg.dev/ons-ci-rm/rm-releases</url>-->
+      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-adamhawtin/test-releases</url>
     </repository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>artifact-registry-snapshots</id>
-<!--      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-ci/rm-snapshots</url>-->
-      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-adamhawtin/test-snapshots</url>
+      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-ci/rm-snapshots</url>
     </snapshotRepository>
     <repository>
       <id>artifact-registry-releases</id>
-<!--      <url>artifactregistry://europe-west2-maven.pkg.dev/ons-ci-rm/rm-releases</url>-->
-      <url>artifactregistry://europe-west2-maven.pkg.dev/ssdc-rm-adamhawtin/test-releases</url>
+      <url>artifactregistry://europe-west2-maven.pkg.dev/ons-ci-rm/rm-releases</url>
     </repository>
   </distributionManagement>
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove snapshot cloudbuild, we don't want snapshots from main once we have release builds

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Remove snapshot cloudbuild
- Add pom version reminder to PR template

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
N/A

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/4agen7g6/431-spike-sort-out-java-artifact-release-builds-and-using-release-artifacts-in-service-release-builds-1-day