### PR TITLE
974 add exception handling to the sample validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-shared-sample-validation</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/RegexRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/RegexRuleTest.java
@@ -9,6 +9,10 @@ class RegexRuleTest {
   private static final String TEST_REGEX_UK_MOBILE_NUMBER = "^07[0-9]{9}$";
   private static final String TEST_REGEX_UK_MOBILE_NUMBER_ERROR = "Not a valid UK mobile number";
 
+  private static final String TEST_REGEX_PRINTABE_ASCII_ONLY = "[ -~]*";
+  private static final String TEST_REGEX_PRINTABE_ASCII_ONLY_ERROR =
+      "Email contains non-ASCII characters";
+
   @Test
   void checkValidityValidPhoneNumber() {
     RegexRule underTest =
@@ -43,5 +47,35 @@ class RegexRuleTest {
 
     Optional<String> actualResult = underTest.checkValidity("07123456789123456789");
     assertThat(actualResult).isPresent().contains(TEST_REGEX_UK_MOBILE_NUMBER_ERROR);
+  }
+
+  @Test
+  void checkValidityValidEmailContainsPrintableAsciiOnly() {
+    RegexRule underTest =
+        new RegexRule(TEST_REGEX_PRINTABE_ASCII_ONLY, TEST_REGEX_PRINTABE_ASCII_ONLY_ERROR);
+
+    Optional<String> actualResult = underTest.checkValidity("valid@mail.com");
+    assertThat(actualResult).isNotPresent();
+  }
+
+  @Test
+  void checkValidityInvalidEmailContainsNonAscii() {
+    RegexRule underTest =
+        new RegexRule(TEST_REGEX_PRINTABE_ASCII_ONLY, TEST_REGEX_PRINTABE_ASCII_ONLY_ERROR);
+
+    Optional<String> actualResult = underTest.checkValidity("\u00F6invalid@mail.com");
+    assertThat(actualResult).isPresent().contains(TEST_REGEX_PRINTABE_ASCII_ONLY_ERROR);
+  }
+
+  @Test
+  void checkValidityInvalidEmailContainsNonPrintableAscii() {
+    RegexRule underTest =
+        new RegexRule(TEST_REGEX_PRINTABE_ASCII_ONLY, TEST_REGEX_PRINTABE_ASCII_ONLY_ERROR);
+
+    Optional<String> actualResult = underTest.checkValidity((char) 31 + "invalid@mail.com");
+    assertThat(actualResult).isPresent().contains(TEST_REGEX_PRINTABE_ASCII_ONLY_ERROR);
+
+    actualResult = underTest.checkValidity((char) 127 + "invalid@mail.com");
+    assertThat(actualResult).isPresent().contains(TEST_REGEX_PRINTABE_ASCII_ONLY_ERROR);
   }
 }

--- a/src/test/resources/example-validator-config.json
+++ b/src/test/resources/example-validator-config.json
@@ -76,6 +76,11 @@
       {
         "className": "uk.gov.ons.ssdc.common.validation.EmailRule",
         "mandatory": true
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+        "expression": "[ -~]",
+        "userFriendlyError": "Email contains non-ASCII characters"
       }
     ]
   }

--- a/src/test/resources/example-validator-config.json
+++ b/src/test/resources/example-validator-config.json
@@ -8,6 +8,11 @@
       {
         "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
         "maxLength": 60
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+        "expression": "[ -~]*",
+        "userFriendlyError": "Address line 1 contains non-printable or non-ASCII characters"
       }
     ]
   },
@@ -17,6 +22,11 @@
       {
         "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
         "maxLength": 60
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+        "expression": "[ -~]*",
+        "userFriendlyError": "Address line 2 contains non-printable or non-ASCII characters"
       }
     ]
   },
@@ -26,6 +36,11 @@
       {
         "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
         "maxLength": 60
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+        "expression": "[ -~]*",
+        "userFriendlyError": "Address line 3 contains non-printable or non-ASCII characters"
       }
     ]
   },
@@ -34,6 +49,11 @@
     "rules": [
       {
         "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+        "expression": "[ -~]*",
+        "userFriendlyError": "Town name contains non-printable or non-ASCII characters"
       }
     ]
   },
@@ -42,6 +62,11 @@
     "rules": [
       {
         "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+      },
+      {
+        "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+        "expression": "[ -~]*",
+        "userFriendlyError": "Postcode contains non-printable or non-ASCII characters"
       }
     ]
   },
@@ -79,8 +104,8 @@
       },
       {
         "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
-        "expression": "[ -~]",
-        "userFriendlyError": "Email contains non-ASCII characters"
+        "expression": "[ -~]*",
+        "userFriendlyError": "Email contains non-printable or non-ASCII characters"
       }
     ]
   }


### PR DESCRIPTION
# Has the POM been updated?

The [pom.xml](pom.xml) file `project.version` must be bumped appropriately on any code changes.

* [ ] the POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

During CRIS we had non-ascii character in the sample file, what caused job processor error, rather than handling it with a validation rule.

I decided to use the Regex rule to avoid importing additional variables and adding another single-purpose Rule implementation.
The `userFriendlyError` field should be just enough to figure out what the validation rule is doing

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

Added a Regex rule for all String fields of the sample that will catch any non-printable or non-ascii characters during sample file processing. 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

Run the `make test`

Create a survey using the new  sample rules and try to upload a sample file with non-ascii and non-printable ascii-character, check if job fails.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/WKntfrEM/974-add-exception-handling-to-the-sample-validation-5

# Screenshots (if appropriate):