### PR TITLE
Add non-ascii char handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-shared-sample-validation</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.1-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
@@ -69,7 +69,10 @@ class EmailRuleTest {
             "local-with-”-quotes@domain.com",
             "domain-starts-with-a-dot@.domain.com",
             "brackets(in)local@domain.com",
-            "incorrect-punycode@xn---something.com")
+            "incorrect-punycode@xn---something.com",
+            " nonascii@example.com ",
+            "nonascii@example.com",
+            "\u00F6nonascii@mail.com")
         .map(Arguments::of);
   };
 


### PR DESCRIPTION
# Has the POM been updated?

The [pom.xml](pom.xml) file `project.version` must be bumped appropriately on any code changes.

* [x] the POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

During CRIS we had non-ascii character in the sample file, what caused job processor error, rather than handling it with a validation rule.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

I added exception handling, which in effect fails the job in the email validation rule where it attempts to convert the email to ascii.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

Run make test.

Build and run all the branches made for this ticket locally and try to load a sample file with a non ASCII character (attached to the Trello card), check that the job fails with validated_error rather than gets stuck.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/ALE8UeJT/1052-add-non-ascii-character-handling-to-the-email-validator-kp

# Screenshots (if appropriate):