### PR TITLE
1234 dependabot patch label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "patch"
+      - "dependencies"


### PR DESCRIPTION
# Motivation and Context
All dependabot PRs are currently blocked because they don’t include our mandatory versioning labels, which obscures which ones pass the tests without a deeper dive.

# What has changed
Added dependabot.yml file
Added labels to the dependabot config file

# How to test?
Check I've used the correct packages ecosystem for the repo
Check the labels

# Links
https://trello.com/c/ZPLTDik6

# Screenshots (if appropriate):