### PR TITLE
Upgrade to Spring Boot 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.2</version>
+    <version>3.5.7</version>
     <relativePath/>
   </parent>
 
@@ -160,6 +160,11 @@
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-55</artifactId>
       <version>2.12.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+      <version>1.9.24</version>
     </dependency>
 
     <!-- Test Dependencies below this point -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-shared-sample-validation</artifactId>
-  <version>1.6.2-SNAPSHOT</version>
+  <version>1.6.3-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
# Has the POM been updated?

The [pom.xml](pom.xml) file `project.version` must be bumped appropriately on any code changes.

* [x] the POM has been updated with an appropriate version bump if required

# Motivation and Context
Fixes a vulnerability in a dependency of the Spring Boot starter

# What has changed
Upgraded SB starter to 3.5.7 and added a required dependency

# How to test?
Build locally, run ATs etc

# Links
SDCSRM-1185

# Screenshots (if appropriate):