### PR TITLE
Changes required for corporate Macs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/*
 .DS_Store
 # Megalinter reports
 megalinter-reports/
+# Podman secrets
+podman-build-secret*

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
 
 build:
-	mvn clean install
+	CONTAINER_CLI=$(DOCKER) mvn clean install
 
 build-no-test:
 	CONTAINER_CLI=$(DOCKER) mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true -Djacoco.skip=true

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 build:
 	mvn clean install
 
 build-no-test:
-	mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true -Djacoco.skip=true
+	CONTAINER_CLI=$(DOCKER) mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true -Djacoco.skip=true
 
 format:
 	mvn fmt:format
@@ -14,16 +17,16 @@ check:
 	mvn fmt:check pmd:check
 
 test:
-	mvn clean verify jacoco:report
+	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report
 
 megalint:  ## Run the mega-linter.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		oxsecurity/megalinter:v8
 
 megalint-fix:  ## Run the mega-linter and attempt to auto fix any issues.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		-e APPLY_FIXES=all \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # ssdc-shared-sample-validation
 Shared/common classes which are used to validate sample data for Survey Collection &amp; Ingestion
+
+
+## Building
+Podman and Docker are both supported for building and running the application.
+By default the Makefile will use `docker` unless you are on an `arm64` architecture (e.g. M1/M2 Mac) in which case it will use `podman`.
+You can override this by setting the `DOCKER` environment variable to either `docker` or `podman`.
+For example, to force using `docker` on an M1/M2 Mac:
+```shell
+DOCKER=docker make <command>
+```
+
+To run all the tests and build the image
+
+```shell
+   mvn clean install
+   make build
+```
+
+Just build the image
+
+```shell
+    mvn -DskipTests -DskipITs -DdockerCompose.skip
+    make build-no-test

--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ DOCKER=docker make <command>
 To run all the tests and build the image
 
 ```shell
-   mvn clean install
    make build
 ```
 
 Just build the image
 
 ```shell
-    mvn -DskipTests -DskipITs -DdockerCompose.skip
     make build-no-test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-shared-sample-validation</artifactId>
-  <version>1.6.3-SNAPSHOT</version>
+  <version>1.6.4-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
# Has the POM been updated?

The [pom.xml](pom.xml) file `project.version` must be bumped appropriately on any code changes.

* [x] the POM has been updated with an appropriate version bump if required

# Motivation and Context
In order to support the new corporate MacBooks we need to make changes to how images are built.

# What has changed
- Added ability to use podman or docker when building 
- Added info in README

# How to test?
Run and build it on both old and new macbooks (add `--no-cache` to the docker build to double check the build commands works fine on a blank slate)
Run both images in GCP and check it works as expected

# Links
[SDCSRM-1481](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1481)