### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
 

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ build-no-test:
 	CONTAINER_CLI=$(DOCKER) mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true -Djacoco.skip=true
 
 format:
-	mvn fmt:format
+	mvn spotless:apply
 
 format-check:
-	mvn fmt:check
+	mvn spotless:check
 
 check:
-	mvn fmt:check pmd:check
+	mvn spotless:check pmd:check
 
 test:
 	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,9 @@
   </parent>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>21</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
   </properties>
 
   <distributionManagement>
@@ -44,7 +45,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.11</version>
         <executions>
           <execution>
             <goals>
@@ -84,8 +85,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.16.0</version>
+        <version>3.23.0</version>
         <configuration>
+          <targetJdk>${java.version}</targetJdk>
           <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
@@ -105,23 +107,32 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Spotless (replacement for fmt-maven-plugin) -->
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.8</version>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.43.0</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.22.0</version> <!-- Java 21 compatible -->
+            </googleJavaFormat>
+          </java>
+        </configuration>
         <executions>
           <execution>
             <goals>
-              <goal>format</goal>
+              <goal>check</goal>
             </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <encoding>UTF-8</encoding>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
@@ -136,7 +147,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.20</version>
+              <version>1.18.30</version>
             </path>
           </annotationProcessorPaths>
         </configuration>
@@ -153,7 +164,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/common/validation/EmailRuleTest.java
@@ -74,7 +74,8 @@ class EmailRuleTest {
             "nonascii@example.com",
             "\u00F6nonascii@mail.com")
         .map(Arguments::of);
-  };
+  }
+  ;
 
   @ParameterizedTest
   @MethodSource("validEmailProvider")


### PR DESCRIPTION
# Motivation and Context
Upgrade to Java 21 from 17.

# What has changed
- Upgraded to use Java 21 in the pom and to build using the Java 21 docker image.
- Updated checks to use spotless rather than fmt
- Updated Git Actions file to use Java 21
- Minor formatting fix

# How to test?
- Install Java 21 locally using the dev-tools install script (currently in PR)
- All checks and tests should pass

# Links
[SDCSRM-1570](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570)
https://github.com/ONSdigital/ssdc-rm-dev-tools/pull/176

[SDCSRM-1570]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ